### PR TITLE
fix(ci): make the Nix build work with NES_ENABLE_MEOS=OFF and stock paho-mqtt-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,13 @@ endif ()
 
 add_custom_target(build_all_plugins)
 
+# Declared here so add_compile_definitions reaches all sibling nes-* targets.
+# nes-plugins/CMakeLists.txt re-declares the same option (no-op when cached).
+option(NES_ENABLE_MEOS "Enable MEOS plugin (requires libmeos installed on the system)" ON)
+if(NES_ENABLE_MEOS)
+    add_compile_definitions(NES_ENABLE_MEOS)
+endif()
+
 # Add target for common lib, which contains a minimal set
 # of shared functionality used by all components of nes
 file(GLOB NES_DIRECTORIES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "nes-*")

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,8 @@
           tbb
           python3
           openjdk21
+          paho-mqtt-c
+          paho-mqtt-cpp
         ]) ++ [ follyPkg antlr4Pkg ];
 
         antlr4Jar = pkgs.fetchurl {
@@ -244,6 +246,7 @@
             "-DNES_ENABLES_TESTS=ON"
             "-DCMAKE_MODULE_PATH=${libdwarfModule}/share/cmake/Modules"
             "-DANTLR4_JAR_LOCATION=${antlr4Jar}"
+            "-DNES_ENABLE_MEOS=OFF"
           ];
 
           enableParallelBuilding = true;
@@ -347,6 +350,7 @@
               "-DLLVM_DIR=${commonCmakeEnv.LLVM_DIR}"
               "-DANTLR4_JAR_LOCATION=${antlr4Jar}"
               "-DCMAKE_MODULE_PATH=${libdwarfModule}/share/cmake/Modules"
+              "-DNES_ENABLE_MEOS=OFF"
             ];
             shellHook = ''
               unset NES_PREBUILT_VCPKG_ROOT

--- a/nes-physical-operators/CMakeLists.txt
+++ b/nes-physical-operators/CMakeLists.txt
@@ -19,7 +19,11 @@ get_source(nes-physical-operators NES_PHYSICAL_OPERATORS_SOURCE_FILES)
 
 # Add Library
 add_library(nes-physical-operators ${NES_PHYSICAL_OPERATORS_SOURCE_FILES})
-target_link_libraries(nes-physical-operators PUBLIC nes-sources nes-sinks nes-nautilus nes-meos)
+if(NES_ENABLE_MEOS)
+    target_link_libraries(nes-physical-operators PUBLIC nes-sources nes-sinks nes-nautilus nes-meos)
+else()
+    target_link_libraries(nes-physical-operators PUBLIC nes-sources nes-sinks nes-nautilus)
+endif()
 target_include_directories(nes-physical-operators PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include/nebulastream/>)

--- a/nes-physical-operators/src/Aggregation/Function/Meos/CMakeLists.txt
+++ b/nes-physical-operators/src/Aggregation/Function/Meos/CMakeLists.txt
@@ -10,5 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(NES_ENABLE_MEOS)
 add_plugin(TemporalSequence AggregationPhysicalFunction nes-physical-operators TemporalSequenceAggregationPhysicalFunction.cpp)
 add_plugin(Var AggregationPhysicalFunction nes-physical-operators VarAggregationFunction.cpp)
+endif()

--- a/nes-physical-operators/src/Functions/Meos/CMakeLists.txt
+++ b/nes-physical-operators/src/Functions/Meos/CMakeLists.txt
@@ -10,9 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(NES_ENABLE_MEOS)
 add_plugin(TemporalIntersects PhysicalFunction nes-physical-operators TemporalIntersectsPhysicalFunction.cpp)
 add_plugin(TemporalIntersectsGeometry PhysicalFunction nes-physical-operators TemporalIntersectsGeometryPhysicalFunction.cpp)
 add_plugin(TemporalAIntersectsGeometry PhysicalFunction nes-physical-operators TemporalAIntersectsGeometryPhysicalFunction.cpp)
 add_plugin(TemporalEContainsGeometry PhysicalFunction nes-physical-operators TemporalEContainsGeometryPhysicalFunction.cpp)
 add_plugin(TemporalEDWithinGeometry PhysicalFunction nes-physical-operators TemporalEDWithinGeometryPhysicalFunction.cpp)
 add_plugin(TemporalAtStBox PhysicalFunction nes-physical-operators TemporalAtStBoxPhysicalFunction.cpp)
+endif()

--- a/nes-plugins/CMakeLists.txt
+++ b/nes-plugins/CMakeLists.txt
@@ -20,33 +20,36 @@ activate_optional_plugin("Sources/TCPSource" ON)
 # Enable the Generator source plugin; required by systests and repl tests
 activate_optional_plugin("Sources/GeneratorSource" ON)
 activate_optional_plugin("Sinks/VoidSink" ON)
-activate_optional_plugin("Sources/MQTTSource" ON)
-activate_optional_plugin("Sinks/MQTTSink" ON)
+option(NES_ENABLE_MQTT "Enable MQTT source and sink plugins (requires PahoMqttCpp)" ON)
+activate_optional_plugin("Sources/MQTTSource" ${NES_ENABLE_MQTT})
+activate_optional_plugin("Sinks/MQTTSink" ${NES_ENABLE_MQTT})
 
-# MEOS is a dependency
-activate_optional_plugin("MEOS" ON)
-message(STATUS "Enable MEOS Plugin")
+option(NES_ENABLE_MEOS "Enable MEOS plugin (requires libmeos installed on the system)" ON)
+activate_optional_plugin("MEOS" ${NES_ENABLE_MEOS})
+if (NES_ENABLE_MEOS)
+    message(STATUS "Enable MEOS Plugin")
 
-# Detect the platform
-if (APPLE)
-    message(STATUS "Building on macOS")
-    # Set the include and library directories for Homebrew (macOS)
-    set(MEOS_INCLUDE_DIR "/opt/homebrew/include" CACHE PATH "Path to MEOS include directory")
-    set(MEOS_PLUGIN_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include" CACHE PATH "Path to MEOS plugin include directory")
-    include_directories(SYSTEM ${MEOS_INCLUDE_DIR} ${MEOS_PLUGIN_INCLUDE_DIR})
-    include_directories(SYSTEM ${MEOS_INCLUDE_DIR} ${MEOS_PLUGIN_INCLUDE_DIR})
-    link_directories(${MEOS_LIBRARY_DIR} )
+    # Detect the platform
+    if (APPLE)
+        message(STATUS "Building on macOS")
+        # Set the include and library directories for Homebrew (macOS)
+        set(MEOS_INCLUDE_DIR "/opt/homebrew/include" CACHE PATH "Path to MEOS include directory")
+        set(MEOS_PLUGIN_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include" CACHE PATH "Path to MEOS plugin include directory")
+        include_directories(SYSTEM ${MEOS_INCLUDE_DIR} ${MEOS_PLUGIN_INCLUDE_DIR})
+        include_directories(SYSTEM ${MEOS_INCLUDE_DIR} ${MEOS_PLUGIN_INCLUDE_DIR})
+        link_directories(${MEOS_LIBRARY_DIR} )
 
-else()
-    message(STATUS "Building on Linux")
-
-    # Default behavior for Linux
-    find_package(meos REQUIRED)
-    if(meos_FOUND)
-        message(STATUS "MEOS found: include=${meos_INCLUDE_DIR}, library=${meos}")
-        include_directories(SYSTEM ${meos_INCLUDE_DIR})
     else()
-        message(FATAL_ERROR "MEOS library not found")
+        message(STATUS "Building on Linux")
+
+        # Default behavior for Linux
+        find_package(meos REQUIRED)
+        if(meos_FOUND)
+            message(STATUS "MEOS found: include=${meos_INCLUDE_DIR}, library=${meos}")
+            include_directories(SYSTEM ${meos_INCLUDE_DIR})
+        else()
+            message(FATAL_ERROR "MEOS library not found")
+        endif()
     endif()
 endif()
 

--- a/nes-plugins/Sinks/MQTTSink/CMakeLists.txt
+++ b/nes-plugins/Sinks/MQTTSink/CMakeLists.txt
@@ -23,5 +23,10 @@ target_include_directories(mqtt_sink_validation_plugin_library
 )
 
 find_package(PahoMqttCpp CONFIG REQUIRED)
-target_link_libraries(mqtt_sink_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3-static)
-target_link_libraries(mqtt_sink_validation_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3-static)
+if(TARGET PahoMqttCpp::paho-mqttpp3-static)
+    target_link_libraries(mqtt_sink_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3-static)
+    target_link_libraries(mqtt_sink_validation_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3-static)
+else()
+    target_link_libraries(mqtt_sink_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3)
+    target_link_libraries(mqtt_sink_validation_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3)
+endif()

--- a/nes-plugins/Sources/MQTTSource/CMakeLists.txt
+++ b/nes-plugins/Sources/MQTTSource/CMakeLists.txt
@@ -23,5 +23,10 @@ target_include_directories(mqtt_source_validation_plugin_library
 )
 
 find_package(PahoMqttCpp CONFIG REQUIRED)
-target_link_libraries(mqtt_source_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3-static)
-target_link_libraries(mqtt_source_validation_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3-static)
+if(TARGET PahoMqttCpp::paho-mqttpp3-static)
+    target_link_libraries(mqtt_source_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3-static)
+    target_link_libraries(mqtt_source_validation_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3-static)
+else()
+    target_link_libraries(mqtt_source_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3)
+    target_link_libraries(mqtt_source_validation_plugin_library PRIVATE PahoMqttCpp::paho-mqttpp3)
+endif()

--- a/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
+++ b/nes-query-optimizer/src/RewriteRules/LowerToPhysical/LowerToPhysicalWindowedAggregation.cpp
@@ -54,8 +54,10 @@
 #include <QueryExecutionConfiguration.hpp>
 #include <RewriteRuleRegistry.hpp>
 // Special-case lowering for TEMPORAL_SEQUENCE (multi-input) aggregation
+#ifdef NES_ENABLE_MEOS
 #include <Operators/Windows/Aggregations/Meos/TemporalSequenceAggregationLogicalFunctionV2.hpp>
 #include <Aggregation/Function/Meos/TemporalSequenceAggregationPhysicalFunction.hpp>
+#endif
 
 namespace NES
 {
@@ -128,6 +130,7 @@ getAggregationPhysicalFunctions(const WindowedAggregationLogicalOperator& logica
         const auto name = descriptor->getName();
 
         // Custom lowering path for TEMPORAL_SEQUENCE: needs three field functions (lon, lat, ts)
+#ifdef NES_ENABLE_MEOS
         if (name == std::string_view("TemporalSequence"))
         {
             auto tsDescriptor = std::dynamic_pointer_cast<TemporalSequenceAggregationLogicalFunctionV2>(descriptor);
@@ -159,6 +162,7 @@ getAggregationPhysicalFunctions(const WindowedAggregationLogicalOperator& logica
             aggregationPhysicalFunctions.push_back(std::move(phys));
             continue;
         }
+#endif
 
         // Default path: use registry for single-input aggregations
         auto aggregationInputFunction = QueryCompilation::FunctionProvider::lowerFunction(descriptor->onField);


### PR DESCRIPTION
The Nix devShell configures and builds off main: paho-mqtt-c and paho-mqtt-cpp are provided in the flake, the MQTT source and sink plugins are gracefully optional behind NES_ENABLE_MQTT and link PahoMqttCpp only when the target is present, and the MEOS plugin CMake guards let the tree configure with NES_ENABLE_MEOS=OFF.