### PR TITLE
Build the libmeos dependency image with all MEOS families via -DALL

### DIFF
--- a/docker/dependency/Base.dockerfile
+++ b/docker/dependency/Base.dockerfile
@@ -67,13 +67,30 @@ RUN apt update -y && apt install -y \
     libgeos-dev \
     libgeos++-dev \
     libgeos-c1v5 \
-    libxml2-dev
+    libxml2-dev \
+    zlib1g-dev \
+    libh3-dev \
+    libgdal-dev \
+    autoconf \
+    automake \
+    libtool \
+    pkg-config
 
-# Build MobilityDB with MEOS enabled using GCC
-RUN git clone https://github.com/MobilityDB/MobilityDB.git -b master /usr/local/src/MobilityDB \
-    && mkdir -p /usr/local/src/MobilityDB/build \
-    && cd /usr/local/src/MobilityDB/build \
-    && cmake -DMEOS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. \
+# Build MobilityDB with MEOS and ALL optional families enabled using GCC.
+# -DALL=ON mirrors the ecosystem-wide provision-meos recipe (all present and
+# future families: CBUFFER/NPOINT/POSE/RGEO/QUADBIN/H3/POINTCLOUD/RASTER/…), so
+# the libmeos the NES MEOS operators link against matches CI. POINTCLOUD builds
+# without PostgreSQL as of MobilityDB #1370 (cmake pointcloud_libpc, libxml2+zlib).
+# Pinned to an upstream master commit for a reproducible dependency image.
+RUN git clone https://github.com/MobilityDB/MobilityDB.git /usr/local/src/MobilityDB \
+    && cd /usr/local/src/MobilityDB \
+    && git checkout 5c5b3cd25b2dba55a137eeacc4b133998cbc6530 \
+    && mkdir -p build \
+    && cd build \
+    && cmake -DMEOS=ON -DALL=ON -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
+        -DH3_INCLUDE_DIR=/usr/include/h3 \
+        -DH3_LIBRARY=/usr/lib/$(gcc -dumpmachine)/libh3.so .. \
     && make -j$(nproc) \
     && make install \
     && ldconfig


### PR DESCRIPTION
## What

The dependency image (`docker/dependency/Base.dockerfile`) built libmeos with only `-DMEOS=ON`, so the NES MEOS operators linked against a **single-family** libmeos. This builds it with `-DALL=ON` instead, so every optional MEOS family (CBUFFER, NPOINT, POSE, RGEO, QUADBIN, H3, POINTCLOUD, RASTER, …) is present — matching the all-families libmeos the rest of the MobilityDB binding ecosystem builds.

## Changes

- `-DMEOS=ON` → `-DMEOS=ON -DALL=ON` in the MobilityDB build step.
- Add the family build dependencies: `libh3-dev`, `libgdal-dev`, `zlib1g-dev`, `autoconf`, `automake`, `libtool`, `pkg-config` (`libxml2-dev` was already present).
- Pin the MobilityDB checkout to an upstream `master` commit for a reproducible dependency image instead of a floating branch.

## Notes

- POINTCLOUD builds without PostgreSQL as of MobilityDB #1370 (a cmake `pointcloud_libpc` static lib over libxml2 + zlib), so no PGDG/`pg_config` provisioning is needed.
- Editing `docker/dependency/` changes the dependency-image hash (`hash_dependencies.sh`), so CI rebuilds the image and exercises this build.

## Verification

Locally, `cmake -DMEOS=ON -DALL=ON` on the pinned commit builds `libmeos.so` cleanly, with exported symbols for every family (h3, quadbin, npoint, cbuffer, pose, rgeo, trgeometry, raster/raquet, pointcloud/pcpoint).